### PR TITLE
policy fix

### DIFF
--- a/access-mgmt.tf
+++ b/access-mgmt.tf
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "s3_bucket_policy" {
     ]
 
     principals {
-      type        = "CanonicalUser"
+      type        = "AWS"
       identifiers = ["${aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn}"]
     }
   }  


### PR DESCRIPTION
the aws principal specified in the `aws_iam_policy_document` for `s3_bucket_policy` was using CanonicalUser, which in the context of which it is applied in this script, is not valid. Updated this to using "AWS" - [aws docs](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Principal)